### PR TITLE
add cancellation option

### DIFF
--- a/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/minecraft/actions/PlaceBlockAction.kt
+++ b/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/minecraft/actions/PlaceBlockAction.kt
@@ -12,18 +12,21 @@ import org.bukkit.Material
  *
  * Summons a block at given location.
  *
+ * @param cancel If block placing should be cancelled.
  * @param at The location to spawn block at.
  * @param blockType The block to spawn.
  */
 @Serializable
 @SerialName("geary:place_block")
-public data class PlaceBlockAction(
+data class PlaceBlockAction(
+    val cancel: Boolean = false,
     val at: ConfigurableLocation,
     val blockType: Material,
 ) : GearyAction() {
     private val GearyEntity.location by at
 
     override fun GearyEntity.run(): Boolean {
+        if (!cancel)
         location.block.type = blockType
         return true
     }


### PR DESCRIPTION
![Screen Recording 2021-09-11 at 10 03 48 p m](https://user-images.githubusercontent.com/62521371/132960368-97b0f5bd-3ccc-48ed-9551-150c952a6143.gif)

Useful for mobdrops that normally count as blocks. Such as Makihige Shell, Chimokami Tail, Inbyo Fur etc
sidenote: didnt show it here but it does infact not cancel normal Obsidian
