### PR TITLE
Custom Food System

### DIFF
--- a/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/papermc/GearyCommonsPlugin.kt
+++ b/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/papermc/GearyCommonsPlugin.kt
@@ -2,10 +2,7 @@ package com.mineinabyss.geary.papermc
 
 import com.mineinabyss.geary.addon.autoscan
 import com.mineinabyss.geary.papermc.dsl.gearyAddon
-import com.mineinabyss.geary.papermc.systems.DeathMessageSystem
-import com.mineinabyss.geary.papermc.systems.NoBreedingSystem
-import com.mineinabyss.geary.papermc.systems.NoMobInteractionsSystem
-import com.mineinabyss.geary.papermc.systems.WearableItemSystem
+import com.mineinabyss.geary.papermc.systems.*
 import com.mineinabyss.geary.papermc.systems.bridge.DeathBridge
 import com.mineinabyss.geary.papermc.systems.bridge.ItemActionsBridge
 import com.mineinabyss.geary.papermc.systems.bridge.MobActionsBridge
@@ -30,6 +27,7 @@ class GearyCommonsPlugin : JavaPlugin() {
         registerEvents(
             DeathMessageSystem(),
             WearableItemSystem(),
+            CustomFoodSystem(),
             ItemActionsBridge(),
             MobActionsBridge(),
             NoMobInteractionsSystem(),

--- a/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/papermc/components/Food.kt
+++ b/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/papermc/components/Food.kt
@@ -13,6 +13,8 @@ import org.bukkit.potion.PotionEffect
  * @param hunger The amount of hunger this item restores.
  * @param saturation The amount of saturation this item gives.
  * @param replacement The item to replace with after consuming. If null it will subtract one from the stack.
+ * @param effectChance The chance of effects being applied.
+ * @param effectList The effects this item can give.
  */
 @Serializable
 @SerialName("geary:food")

--- a/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/papermc/components/Food.kt
+++ b/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/papermc/components/Food.kt
@@ -1,0 +1,25 @@
+package com.mineinabyss.geary.papermc.components
+
+import com.mineinabyss.idofront.serialization.PotionEffectSerializer
+import com.mineinabyss.idofront.serialization.SerializableItemStack
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.bukkit.potion.PotionEffect
+
+/**
+ * `geary:food`
+ * Lets an item have custom food properties.
+ *
+ * @param hunger The amount of hunger this item restores.
+ * @param saturation The amount of saturation this item gives.
+ * @param replacement The item to replace with after consuming. If null it will subtract one from the stack.
+ */
+@Serializable
+@SerialName("geary:food")
+class Food(
+    val hunger: Int,
+    val saturation: Int,
+    val replacement: SerializableItemStack? = null,
+    val effectChance: Double = 0.0,
+    val effectList: List<@Serializable(with = PotionEffectSerializer::class) PotionEffect> = emptyList(),
+)

--- a/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/papermc/systems/CustomFoodSystem.kt
+++ b/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/papermc/systems/CustomFoodSystem.kt
@@ -6,7 +6,6 @@ import org.bukkit.GameMode
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerItemConsumeEvent
-import org.bukkit.inventory.EquipmentSlot
 import kotlin.random.Random
 
 class CustomFoodSystem : Listener {
@@ -14,25 +13,17 @@ class CustomFoodSystem : Listener {
     @EventHandler
     fun PlayerItemConsumeEvent.onConsumeFood() {
         val inv = player.inventory
-        val hand = when {
-            inv.itemInMainHand.isSimilar(item) -> EquipmentSlot.HAND
-            inv.itemInOffHand.isSimilar(item) -> EquipmentSlot.OFF_HAND
-            else -> return
-        }
-        val item = if (hand == EquipmentSlot.HAND) inv.itemInMainHand else inv.itemInOffHand
+        val item = if (inv.itemInMainHand.isSimilar(item)) inv.itemInMainHand else inv.itemInOffHand
         val gearyFood = item.toGearyOrNull(player)?.get<Food>() ?: return
         val replacement = gearyFood.replacement?.toItemStack()
         isCancelled = true // Cancel vanilla behaviour
 
         if (player.gameMode != GameMode.CREATIVE) {
             if (replacement != null) {
-                if (item.amount > 1) {
-                    if (player.inventory.firstEmpty() != -1) inv.addItem(replacement)
-                    else player.world.dropItemNaturally(player.location, replacement)
-                    item.subtract()
-                }
-                else inv.setItem(hand, replacement)
-            } else item.subtract()
+                if (player.inventory.firstEmpty() != -1) inv.addItem(replacement)
+                else player.world.dropItemNaturally(player.location, replacement)
+            }
+            item.subtract()
 
             if (gearyFood.effectList.isNotEmpty() && Random.nextDouble(0.0, 1.0) <= gearyFood.effectChance)
                 player.addPotionEffects(gearyFood.effectList)

--- a/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/papermc/systems/CustomFoodSystem.kt
+++ b/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/papermc/systems/CustomFoodSystem.kt
@@ -1,0 +1,31 @@
+package com.mineinabyss.geary.papermc.systems
+
+import com.mineinabyss.geary.papermc.components.Food
+import com.mineinabyss.looty.tracking.toGearyOrNull
+import org.bukkit.GameMode
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerItemConsumeEvent
+import org.bukkit.potion.PotionEffect
+import kotlin.random.Random
+
+class CustomFoodSystem : Listener {
+
+    @EventHandler
+    fun PlayerItemConsumeEvent.onConsumeFood() {
+        val gearyFood = item.toGearyOrNull(player)?.get<Food>() ?: return
+        isCancelled = true // Cancel vanilla behaviour
+        if (player.gameMode == GameMode.CREATIVE) return
+
+        if (gearyFood.replacement != null) setItem(gearyFood.replacement.toItemStack()) else item.subtract()
+        if (gearyFood.effectList.isNotEmpty() && gearyFood.effectChance > 0.0) {
+            if (Random.nextDouble(0.0, 1.0) <= gearyFood.effectChance)
+                gearyFood.effectList.forEach { e ->
+                    player.addPotionEffect(PotionEffect(e.type, e.duration, e.amplifier, e.isAmbient, e.hasParticles(), e.hasIcon()))
+                }
+        }
+
+        player.foodLevel += minOf(gearyFood.hunger, 20)
+        player.saturation += minOf(gearyFood.saturation, 20)
+    }
+}

--- a/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/papermc/systems/CustomFoodSystem.kt
+++ b/geary-commons-papermc/src/main/kotlin/com/mineinabyss/geary/papermc/systems/CustomFoodSystem.kt
@@ -6,26 +6,35 @@ import org.bukkit.GameMode
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerItemConsumeEvent
-import org.bukkit.potion.PotionEffect
+import org.bukkit.inventory.EquipmentSlot
 import kotlin.random.Random
 
 class CustomFoodSystem : Listener {
 
     @EventHandler
     fun PlayerItemConsumeEvent.onConsumeFood() {
-        val gearyFood = item.toGearyOrNull(player)?.get<Food>() ?: return
-        isCancelled = true // Cancel vanilla behaviour
-        if (player.gameMode == GameMode.CREATIVE) return
-
-        if (gearyFood.replacement != null) setItem(gearyFood.replacement.toItemStack()) else item.subtract()
-        if (gearyFood.effectList.isNotEmpty() && gearyFood.effectChance > 0.0) {
-            if (Random.nextDouble(0.0, 1.0) <= gearyFood.effectChance)
-                gearyFood.effectList.forEach { e ->
-                    player.addPotionEffect(PotionEffect(e.type, e.duration, e.amplifier, e.isAmbient, e.hasParticles(), e.hasIcon()))
-                }
+        val inv = player.inventory
+        val hand = when {
+            inv.itemInMainHand.isSimilar(item) -> EquipmentSlot.HAND
+            inv.itemInOffHand.isSimilar(item) -> EquipmentSlot.OFF_HAND
+            else -> return
         }
+        val item = if (hand == EquipmentSlot.HAND) inv.itemInMainHand else inv.itemInOffHand
+        val gearyFood = item.toGearyOrNull(player)?.get<Food>() ?: return
 
-        player.foodLevel += minOf(gearyFood.hunger, 20)
-        player.saturation += minOf(gearyFood.saturation, 20)
+        isCancelled = true // Cancel vanilla behaviour
+
+        if (player.gameMode != GameMode.CREATIVE) {
+            if (gearyFood.replacement != null)
+                if (hand == EquipmentSlot.HAND) inv.setItemInMainHand(gearyFood.replacement.toItemStack())
+                else inv.setItemInOffHand(gearyFood.replacement.toItemStack())
+            else item.subtract()
+
+            if (gearyFood.effectList.isNotEmpty() && Random.nextDouble(0.0, 1.0) <= gearyFood.effectChance)
+                gearyFood.effectList.forEach { effect -> player.addPotionEffect(effect) }
+
+            player.foodLevel += minOf(gearyFood.hunger, 20)
+            player.saturation += minOf(gearyFood.saturation, 20)
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 group=com.mineinabyss
 version=0.7
-idofrontVersion=0.12.102
+idofrontVersion=0.12.104
 kotlinVersion=1.6.10
 serverVersion=1.19.2-R0.1-SNAPSHOT
 # Workaround for dokka builds failing on CI, see https://github.com/Kotlin/dokka/issues/1405

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 group=com.mineinabyss
 version=0.7
-idofrontVersion=0.12.104
+idofrontVersion=0.12.105
 kotlinVersion=1.6.10
 serverVersion=1.19.2-R0.1-SNAPSHOT
 # Workaround for dokka builds failing on CI, see https://github.com/Kotlin/dokka/issues/1405


### PR DESCRIPTION
Currently not tested as its not a geary item apparently. Tried it using ashimite meat cooked with this, but it fails the first check as `item.toGearyOrNull(player)` is null? Might be a new issue with 1.19.2 but
```yml
- !<geary:food>
  saturation: 8
  hunger: 10
  replacement:
    prefab: mineinabyss:ashimite_meat_raw
  effectChance: 0.35
  effectList:
    - type: HUNGER
      duration: 10s
      amplifier: 2
      isAmbient: true
      hasParticles: true
      hasIcon: true
  ```